### PR TITLE
Setup for docker 

### DIFF
--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,0 +1,18 @@
+local_resource(
+  name = 'dev:file-transfer-service',
+  cmd = 'mvn compile',
+  deps = ['src/main']
+)
+
+custom_build(
+  ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/file-transfer-service',
+  command = 'mvn compile jib:dockerBuild -Dimage=$EXPECTED_REF',
+  live_update = [
+    sync(
+      local_path = './target/classes',
+      remote_path = '/app/classes'
+    ),
+    restart_container()
+  ],
+  deps = ['./target/classes']
+)

--- a/pom.xml
+++ b/pom.xml
@@ -278,12 +278,6 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>${jib-maven-plugin.version}</version>
-
-                <configuration>
-                    <from>
-                        <image>amazoncorretto:11</image>
-                    </from>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/FileTransferServiceApplication.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/FileTransferServiceApplication.java
@@ -1,0 +1,13 @@
+package uk.gov.companieshouse.filetransferservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class FileTransferServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FileTransferServiceApplication.class, args);
+    }
+}
+


### PR DESCRIPTION
This PR sets up the service to run in a Docker container, with the help of the Jib Maven plugin. The changes in this PR include:

- Adding a Tiltfile.dev file that defines a local_resource and a custom_build that uses the Jib plugin to build a Docker image of the service. The custom_build also specifies a live_update configuration that allows Tilt to sync local changes with the running container.
- Removing the <from> configuration from the Jib plugin in the pom.xml file. This is because the base-image is already defined in the Jib plugin configuration in the Tiltfile.dev.
- Adding a new FileTransferServiceApplication class that bootstraps the service.

Resolves: [BI-12493](https://companieshouse.atlassian.net/browse/BI-12493)
Associated `docker-chs-developement` pr: [docker-chs-development/pull/614](https://github.com/companieshouse/docker-chs-development/pull/614)

[BI-12493]: https://companieshouse.atlassian.net/browse/BI-12493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ