### PR TITLE
Add endpoints to controller

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfiguration.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.filetransferservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+
+@Configuration
+public class ApplicationConfiguration {
+    @Value("${application.namespace}")
+    private String applicationNameSpace;
+
+    /**
+     * Creates the logger used by the application.
+     *
+     * @return the logger
+     */
+    @Bean
+    public Logger logger() {
+        return LoggerFactory.getLogger(applicationNameSpace);
+    }
+}
+

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -109,12 +109,21 @@ public class FileTransferController {
      * Handles the request to retrieve a file's details from S3
      *
      * @param fileId of remote file
-     * @return file details data
+     * @return file details data or 404 if the file is not found
      */
     @GetMapping(path = "/{fileId}")
-    public FileDetailsApi getFileDetails(@PathVariable String fileId) {
-        return new FileDetailsApi();
+    public ResponseEntity<FileDetailsApi> getFileDetails(@PathVariable String fileId) {
+        Optional<FileDetailsApi> fileDetails = fileStorageStrategy.getFileDetails(fileId);
+
+        // Multiline is more readable than single line
+        //noinspection OptionalIsPresent
+        if (fileDetails.isPresent()) {
+            return ResponseEntity.ok(fileDetails.get());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
     }
+
 
     /**
      * Handles the request to delete a file from S3

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -122,6 +122,9 @@ public class FileTransferController {
      * @param fileId of remote file
      */
     @DeleteMapping(path = "/{fileId}")
-    public void delete(@PathVariable String fileId) {
+    public ResponseEntity<Void> delete(@PathVariable String fileId) {
+        fileStorageStrategy.delete(fileId);
+        return ResponseEntity.ok().build();
     }
+
 }

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.filetransferservice.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,22 +11,88 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
-import uk.gov.companieshouse.api.model.efs.submissions.FileDetailApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
+import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
+import uk.gov.companieshouse.filetransferservice.service.file.transfer.FileStorageStrategy;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 @Controller
 @RequestMapping(path = "/files")
 public class FileTransferController {
-    /**
-     * Handles the request to save a file to S3
-     *
-     * @param file the file data
-     * @return id of remote file
-     */
-    @PostMapping
-    public String save(@RequestParam("file") MultipartFile file) {
-        return "123";
+    public static final List<String> ALLOWED_MIME_TYPES = Arrays.asList(
+            "text/plain",
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "application/pdf",
+            "text/csv",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
+            "image/gif",
+            "application/x-rar-compressed",
+            "application/x-tar",
+            "application/x-7z-compressed",
+            "application/xhtml+xml",
+            "application/zip"
+    );
+
+    private final FileStorageStrategy fileStorageStrategy;
+
+    @Autowired
+    public FileTransferController(FileStorageStrategy fileStorageStrategy) {
+        this.fileStorageStrategy = fileStorageStrategy;
     }
+
+    /**
+     * Uploads the specified file to the file transfer service. The file is checked for valid MIME type and size
+     * limits, and an appropriate response is returned containing the ID of the uploaded file or an error message.
+     *
+     * @param file the file to upload
+     * @return a ResponseEntity containing the ID of the uploaded file or an error message
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<String> upload(@RequestParam("file") MultipartFile file) {
+        try {
+            byte[] data = file.getBytes();
+            String fileName = Optional.ofNullable(file.getOriginalFilename()).orElse("");
+            String mimeType = file.getContentType();
+            int size = (int) file.getSize();
+            String extension = getFileExtension(fileName);
+            if (ALLOWED_MIME_TYPES.contains(mimeType)) {
+                FileApi fileApi = new FileApi(fileName, data, mimeType, size, extension);
+                String fileId = fileStorageStrategy.save(fileApi);
+                return ResponseEntity.status(HttpStatus.CREATED).body(fileId);
+            } else {
+                return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body("Unsupported file type");
+            }
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Unable to upload file");
+        }
+    }
+
+    /**
+     * Gets the file extension of the specified file name. For example, if the file name is "document.pdf",
+     * the file extension returned is "pdf". If the file name does not contain a file extension, an empty string
+     * is returned.
+     *
+     * @param fileName the name of the file
+     * @return the file extension
+     */
+    private String getFileExtension(String fileName) {
+        String[] parts = fileName.split("\\.");
+        if (parts.length > 1) {
+            return parts[parts.length - 1];
+        } else {
+            return "";
+        }
+    }
+
 
     /**
      * Handles the request to retrieve a file from S3
@@ -31,8 +100,8 @@ public class FileTransferController {
      * @param id of remote file
      * @return file data
      */
-    @GetMapping(path = "/{fileId}")
-    public FileApi load(@PathVariable String id) {
+    @GetMapping(path = "/{fileId}/download")
+    public FileApi download(@PathVariable String id) {
         return new FileApi();
     }
 
@@ -42,9 +111,9 @@ public class FileTransferController {
      * @param fileId of remote file
      * @return file details data
      */
-    @GetMapping(path = "/check/{fileId}")
-    public FileDetailApi getFileDetails(@PathVariable String fileId) {
-        return new FileDetailApi();
+    @GetMapping(path = "/{fileId}")
+    public FileDetailsApi getFileDetails(@PathVariable String fileId) {
+        return new FileDetailsApi();
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -78,9 +78,11 @@ public class FileTransferController {
                 logger.infoContext(fileId, "Created file", Map.of("id", fileId));
                 return ResponseEntity.status(HttpStatus.CREATED).body(fileId);
             } else {
-                //noinspection ConstantConditions
                 logger.error("Unable to upload file as it has an invalid mime type",
-                        Map.of("mime type", mimeType, "file name", fileName));
+                        Map.of("mime type",
+                                mimeType != null ? mimeType : "No Mime type",
+                                "file name",
+                                fileName));
                 return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body("Unsupported file type");
             }
         } catch (IOException e) {

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/file/transfer/S3FileStorage.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/file/transfer/S3FileStorage.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.filetransferservice.service.file.transfer;
 
+import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
 
@@ -8,6 +9,7 @@ import java.util.Optional;
 /**
  * An implementation of the FileStorageStrategy for S3
  */
+@Component
 public class S3FileStorage implements FileStorageStrategy {
     /**
      * Upload a file to S3

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# suppress inspection "UnusedProperty" for whole file
+application.namespace=file-transfer-service

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
@@ -8,10 +8,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -23,6 +23,7 @@ import uk.gov.companieshouse.api.model.filetransfer.AvStatusApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.filetransferservice.service.file.transfer.FileStorageStrategy;
+import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -32,14 +33,13 @@ import java.util.Optional;
 public class FileTransferControllerTest {
 
     @Mock
+    private Logger logger;
+
+    @Mock
     private FileStorageStrategy fileStorageStrategy;
 
+    @InjectMocks
     private FileTransferController fileTransferController;
-
-    @BeforeEach
-    public void setup() {
-        fileTransferController = new FileTransferController(fileStorageStrategy);
-    }
 
     @Test
     @DisplayName("Test uploading a file with allowed MIME type")

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
@@ -18,9 +18,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
+import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.filetransferservice.service.file.transfer.FileStorageStrategy;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 public class FileTransferControllerTest {
@@ -90,6 +92,32 @@ public class FileTransferControllerTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         verify(fileStorageStrategy, times(1)).delete(fileId);
+    }
+
+    @Test
+    @DisplayName("Test successful retrieval of file details")
+    public void testGetFileDetailsSuccess() {
+        String fileId = "123";
+        FileDetailsApi expectedFileDetails = new FileDetailsApi();
+        when(fileStorageStrategy.getFileDetails(fileId)).thenReturn(Optional.of(expectedFileDetails));
+
+        ResponseEntity<FileDetailsApi> response = fileTransferController.getFileDetails(fileId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(expectedFileDetails, response.getBody());
+        verify(fileStorageStrategy, times(1)).getFileDetails(fileId);
+    }
+
+    @Test
+    @DisplayName("Test retrieval of non-existent file details")
+    public void testGetFileDetailsNotFound() {
+        String fileId = "123";
+        when(fileStorageStrategy.getFileDetails(fileId)).thenReturn(Optional.empty());
+
+        ResponseEntity<FileDetailsApi> response = fileTransferController.getFileDetails(fileId);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(fileStorageStrategy, times(1)).getFileDetails(fileId);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -35,6 +36,7 @@ public class FileTransferControllerTest {
     }
 
     @Test
+    @DisplayName("Test uploading a file with allowed MIME type")
     public void testUploadFileWithAllowedMimeType() {
         MultipartFile mockFile = new MockMultipartFile("test.pdf",
                 "test.pdf",
@@ -55,6 +57,7 @@ public class FileTransferControllerTest {
     }
 
     @Test
+    @DisplayName("Test uploading a file with unsupported MIME type")
     public void testUploadFileWithUnsupportedMimeType() {
         MultipartFile mockFile = new MockMultipartFile("test.txt", "test".getBytes());
 
@@ -66,6 +69,7 @@ public class FileTransferControllerTest {
     }
 
     @Test
+    @DisplayName("Test uploading a file with IOException")
     public void testUploadFileWithIOException() throws IOException {
         MultipartFile mockFile = mock(MultipartFile.class);
         when(mockFile.getBytes()).thenThrow(new IOException());
@@ -75,6 +79,17 @@ public class FileTransferControllerTest {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertEquals("Unable to upload file", response.getBody());
         verify(fileStorageStrategy, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("Test successful file deletion")
+    public void testDeleteFileSuccess() {
+        String fileId = "123";
+
+        ResponseEntity<Void> response = fileTransferController.delete(fileId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(fileStorageStrategy, times(1)).delete(fileId);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
@@ -1,0 +1,80 @@
+package uk.gov.companieshouse.filetransferservice.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.model.filetransfer.FileApi;
+import uk.gov.companieshouse.filetransferservice.service.file.transfer.FileStorageStrategy;
+
+import java.io.IOException;
+
+@ExtendWith(MockitoExtension.class)
+public class FileTransferControllerTest {
+
+    @Mock
+    private FileStorageStrategy fileStorageStrategy;
+
+    private FileTransferController fileTransferController;
+
+    @BeforeEach
+    public void setup() {
+        fileTransferController = new FileTransferController(fileStorageStrategy);
+    }
+
+    @Test
+    public void testUploadFileWithAllowedMimeType() {
+        MultipartFile mockFile = new MockMultipartFile("test.pdf",
+                "test.pdf",
+                "application/pdf",
+                "test".getBytes());
+        FileApi mockFileApi = new FileApi("test.pdf",
+                "test".getBytes(),
+                "application/pdf",
+                4,
+                "pdf");
+        when(fileStorageStrategy.save(mockFileApi)).thenReturn("123");
+
+        ResponseEntity<String> response = fileTransferController.upload(mockFile);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("123", response.getBody());
+        verify(fileStorageStrategy, times(1)).save(mockFileApi);
+    }
+
+    @Test
+    public void testUploadFileWithUnsupportedMimeType() {
+        MultipartFile mockFile = new MockMultipartFile("test.txt", "test".getBytes());
+
+        ResponseEntity<String> response = fileTransferController.upload(mockFile);
+
+        assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE, response.getStatusCode());
+        assertEquals("Unsupported file type", response.getBody());
+        verify(fileStorageStrategy, times(0)).save(any());
+    }
+
+    @Test
+    public void testUploadFileWithIOException() throws IOException {
+        MultipartFile mockFile = mock(MultipartFile.class);
+        when(mockFile.getBytes()).thenThrow(new IOException());
+
+        ResponseEntity<String> response = fileTransferController.upload(mockFile);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("Unable to upload file", response.getBody());
+        verify(fileStorageStrategy, times(0)).save(any());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.filetransferservice.controller;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -16,12 +17,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.model.filetransfer.AvStatusApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.filetransferservice.service.file.transfer.FileStorageStrategy;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
@@ -120,4 +124,62 @@ public class FileTransferControllerTest {
         verify(fileStorageStrategy, times(1)).getFileDetails(fileId);
     }
 
+    @Test
+    @DisplayName("Test successful file download")
+    public void testDownloadSuccess() {
+        String fileId = "123";
+        byte[] content = {0x01, 0x02, 0x03};
+        String mimeType = "text/plain";
+        String fileName = "file.txt";
+
+        var fileDetails = new FileDetailsApi();
+        ReflectionTestUtils.setField(fileDetails, "contentType", mimeType);
+        ReflectionTestUtils.setField(fileDetails, "avStatus", AvStatusApi.CLEAN);
+
+        when(fileStorageStrategy.getFileDetails(fileId))
+                .thenReturn(Optional.of(fileDetails));
+
+        var file = new FileApi(fileName, content, mimeType, content.length, "txt");
+
+        when(fileStorageStrategy.load(fileId))
+                .thenReturn(Optional.of(file));
+
+        ResponseEntity<byte[]> response = fileTransferController.download(fileId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(content.length, Objects.requireNonNull(response.getBody()).length);
+        assertArrayEquals(content, response.getBody());
+        assertEquals(mimeType, Objects.requireNonNull(response.getHeaders().getContentType()).toString());
+        assertEquals("attachment; filename=\"file.txt\"", response.getHeaders().getContentDisposition().toString());
+        assertEquals(content.length, response.getHeaders().getContentLength());
+    }
+
+    @Test
+    @DisplayName("Test unsuccessful file download due to missing file")
+    public void testDownloadFileNotFound() {
+        String fileId = "123";
+
+        when(fileStorageStrategy.getFileDetails(fileId))
+                .thenReturn(Optional.empty());
+
+        ResponseEntity<byte[]> response = fileTransferController.download(fileId);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("Test unsuccessful file download due to non-clean file status")
+    public void testDownloadFileNotClean() {
+        String fileId = "123";
+
+        var fileDetailsApi = new FileDetailsApi();
+        ReflectionTestUtils.setField(fileDetailsApi, "avStatus", AvStatusApi.INFECTED);
+
+        when(fileStorageStrategy.getFileDetails(fileId))
+                .thenReturn(Optional.of(fileDetailsApi));
+
+        ResponseEntity<byte[]> response = fileTransferController.download(fileId);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
 }


### PR DESCRIPTION
# Changes

## FileTransferController:

- Added `POST /upload` endpoint that uploads the specified file to the file transfer service. 
- Changed download endpoint from `GET /{fileID}` to `GET /{fileID}/download` to match the [file-transfer-api](https://github.com/companieshouse/file-transfer-api/blob/3207402c697705c9b15ff5dad8cac9c4c715a3a5/src/routes/index.ts#L13)
- Added `GET /{fileId}/download` endpoint that retrieves the specified file from the file transfer service.
- Changes details endpoint from `GET /check/{fileID}` to `GET /{fileID}` to match [file-transfer-api](https://github.com/companieshouse/file-transfer-api/blob/3207402c697705c9b15ff5dad8cac9c4c715a3a5/src/routes/index.ts#L11)
- Added `GET /{fileId}` endpoint that retrieves the file details for the specified file from the file transfer service.
- Added `DELETE /{fileId}` endpoint that deletes the specified file from the file transfer service.

## S3FileStorage:

- Added @Component annotation to allow Spring to create an instance of the class.

Resolves:
- [BI-12499](https://companieshouse.atlassian.net/browse/BI-12499)
- [BI-12500](https://companieshouse.atlassian.net/browse/BI-12500)
- [BI-12501](https://companieshouse.atlassian.net/browse/BI-12501)
- [BI-12503](https://companieshouse.atlassian.net/browse/BI-12503)

[BI-12499]: https://companieshouse.atlassian.net/browse/BI-12499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ