### PR TITLE
Add security interceptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,6 @@
                 <version>${api-sdk-java.version}</version>
             </dependency>
             <dependency>
-                <groupId>uk.gov.companieshouse</groupId>
-                <artifactId>api-security-java</artifactId>
-                <version>${api-security-java-version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-dependencies.version}</version>
@@ -91,6 +86,11 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-security-java</artifactId>
+            <version>${api-security-java-version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         <aws-java-sdk.version>1.12.343</aws-java-sdk.version>
         <api-helper-java.version>1.4.3</api-helper-java.version>
-        <api-security-java-version>0.2.17</api-security-java-version>
+        <api-security-java-version>0.4.0</api-security-java-version>
 
         <!-- java apis libs -->
         <jaxb-api.version>2.3.1</jaxb-api.version>

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.filetransferservice.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -21,5 +22,11 @@ public class ApplicationConfiguration {
     public Logger logger() {
         return LoggerFactory.getLogger(applicationNameSpace);
     }
+
+    @Bean
+    public InternalUserInterceptor userInterceptor() {
+        return new InternalUserInterceptor(applicationNameSpace);
+    }
+
 }
 

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebMvcConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebMvcConfig.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.filetransferservice.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
+import uk.gov.companieshouse.filetransferservice.security.LoggingInterceptor;
+
+
+@Component
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final LoggingInterceptor loggingInterceptor;
+    private final InternalUserInterceptor internalUserInterceptor;
+
+    @Autowired
+    public WebMvcConfig(LoggingInterceptor loggingInterceptor,
+                        InternalUserInterceptor internalUserInterceptor) {
+        this.loggingInterceptor = loggingInterceptor;
+        this.internalUserInterceptor = internalUserInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor);
+        registry.addInterceptor(internalUserInterceptor);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebSecurityConfig.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.filetransferservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+    /**
+     * Configure Http Security.
+     */
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.httpBasic().disable()
+                .csrf().disable()
+                .formLogin().disable()
+                .logout().disable()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .anyRequest().permitAll();
+    }
+
+    /**
+     * Configure Web Security.
+     */
+    @Override
+    public void configure(WebSecurity web) {
+        // Excluding healthcheck endpoint from security filter
+        web.ignoring().antMatchers("/actuator/**");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,14 +76,14 @@ public class FileTransferController {
             if (ALLOWED_MIME_TYPES.contains(mimeType)) {
                 FileApi fileApi = new FileApi(fileName, data, mimeType, size, extension);
                 String fileId = fileStorageStrategy.save(fileApi);
-                logger.infoContext(fileId, "Created file", Map.of("id", fileId));
+                logger.infoContext(fileId, "Created file", new HashMap<>(Map.of("id", fileId)));
                 return ResponseEntity.status(HttpStatus.CREATED).body(fileId);
             } else {
                 logger.error("Unable to upload file as it has an invalid mime type",
-                        Map.of("mime type",
+                        new HashMap<>(Map.of("mime type",
                                 mimeType != null ? mimeType : "No Mime type",
                                 "file name",
-                                fileName));
+                                fileName)));
                 return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body("Unsupported file type");
             }
         } catch (IOException e) {
@@ -184,7 +185,7 @@ public class FileTransferController {
     @DeleteMapping(path = "/{fileId}")
     public ResponseEntity<Void> delete(@PathVariable String fileId) {
         fileStorageStrategy.delete(fileId);
-        logger.infoContext(fileId, "Deleted file", Map.of("fileId", fileId));
+        logger.infoContext(fileId, "Deleted file", new HashMap<>(Map.of("fileId", fileId)));
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/security/LoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/security/LoggingInterceptor.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.filetransferservice.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.util.RequestLogger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This class manages the logging of the start request and end request.
+ */
+@Component
+public class LoggingInterceptor extends HandlerInterceptorAdapter implements RequestLogger {
+    private final Logger logger;
+
+    /**
+     * Sets the logger used to log out request information.
+     *
+     * @param logger the configured logger
+     */
+    @Autowired
+    public LoggingInterceptor(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean preHandle(@NonNull HttpServletRequest request,
+                             @NonNull HttpServletResponse response,
+                             @NonNull Object handler) {
+        logStartRequestProcessing(request, logger);
+        return true;
+    }
+
+    @Override
+    public void postHandle(@NonNull HttpServletRequest request,
+                           @NonNull HttpServletResponse response,
+                           @NonNull Object handler,
+                           ModelAndView modelAndView) {
+        logEndRequestProcessing(request, response, logger);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/file/transfer/S3FileStorage.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/file/transfer/S3FileStorage.java
@@ -19,7 +19,7 @@ public class S3FileStorage implements FileStorageStrategy {
      */
     @Override
     public String save(FileApi file) {
-        return null;
+        return "";
     }
 
     /**


### PR DESCRIPTION
- Added request interceptor from [api-security-java](https://github.com/companieshouse/api-security-java) to enforce API key authorisation. 
- Added logging interceptor to log requests.
- Fixed a bug where logs using `Map.of` to create log info, but `Map.of` is immutable causing `UnsupportedOperation` exceptions when structured-logging tried to log.

Resolves:
[BI-12507](https://companieshouse.atlassian.net/browse/BI-12507)

[BI-12507]: https://companieshouse.atlassian.net/browse/BI-12507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ