### PR TITLE
Controller refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,6 @@
                 <version>${api-sdk-java.version}</version>
             </dependency>
             <dependency>
-                <groupId>uk.gov.companieshouse</groupId>
-                <artifactId>api-security-java</artifactId>
-                <version>${api-security-java-version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-dependencies.version}</version>
@@ -91,6 +86,11 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-security-java</artifactId>
+            <version>${api-security-java-version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         <aws-java-sdk.version>1.12.343</aws-java-sdk.version>
         <api-helper-java.version>1.4.3</api-helper-java.version>
-        <api-security-java-version>0.2.17</api-security-java-version>
+        <api-security-java-version>0.4.0</api-security-java-version>
 
         <!-- java apis libs -->
         <jaxb-api.version>2.3.1</jaxb-api.version>

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.filetransferservice.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -21,5 +22,11 @@ public class ApplicationConfiguration {
     public Logger logger() {
         return LoggerFactory.getLogger(applicationNameSpace);
     }
+
+    @Bean
+    public InternalUserInterceptor userInterceptor() {
+        return new InternalUserInterceptor(applicationNameSpace);
+    }
+
 }
 

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebMvcConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebMvcConfig.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.filetransferservice.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
+import uk.gov.companieshouse.filetransferservice.security.LoggingInterceptor;
+
+
+@Component
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final LoggingInterceptor loggingInterceptor;
+    private final InternalUserInterceptor internalUserInterceptor;
+
+    @Autowired
+    public WebMvcConfig(LoggingInterceptor loggingInterceptor,
+                        InternalUserInterceptor internalUserInterceptor) {
+        this.loggingInterceptor = loggingInterceptor;
+        this.internalUserInterceptor = internalUserInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor);
+        registry.addInterceptor(internalUserInterceptor);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebSecurityConfig.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.filetransferservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+    /**
+     * Configure Http Security.
+     */
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.httpBasic().disable()
+                .csrf().disable()
+                .formLogin().disable()
+                .logout().disable()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .anyRequest().permitAll();
+    }
+
+    /**
+     * Configure Web Security.
+     */
+    @Override
+    public void configure(WebSecurity web) {
+        // Excluding healthcheck endpoint from security filter
+        web.ignoring().antMatchers("/actuator/**");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileSizeExceptionAdvice.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileSizeExceptionAdvice.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.filetransferservice.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.HashMap;
+
+/**
+ * A controller advice that handles {@link MaxUploadSizeExceededException} exceptions.
+ *
+ * This advice is necessary because the exception will be thrown before it reaches the controller, so it cannot be
+ * handled there. The maximum upload size is configured by the {@code spring.servlet.multipart.max-file-size} property,
+ * which is in turn configured by the {@code MAX_FILE_SIZE} environment variable.
+ *
+ * When a {@code MaxUploadSizeExceededException} is thrown, this advice logs an error message and returns a
+ * {@code ResponseEntity} with an HTTP status code of {@link HttpStatus#PAYLOAD_TOO_LARGE} and a message
+ * indicating that the uploaded file is too large.
+ */
+
+@ControllerAdvice
+public class FileSizeExceptionAdvice {
+    final Logger logger;
+
+    @Autowired
+    public FileSizeExceptionAdvice(final Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Handles {@link MaxUploadSizeExceededException} exceptions by logging an error message and returning a
+     * {@code ResponseEntity} with an HTTP status code of {@link HttpStatus#PAYLOAD_TOO_LARGE} and a message
+     * indicating that the uploaded file is too large.
+     *
+     * @param exception the {@code MaxUploadSizeExceededException} to handle
+     * @return a {@code ResponseEntity} with an HTTP status code of {@link HttpStatus#PAYLOAD_TOO_LARGE}
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    ResponseEntity<?> handleFileTooLarge(MaxUploadSizeExceededException exception) {
+        var loggedVars = new HashMap<String, Object>();
+        loggedVars.put("maxFileSize", exception.getMaxUploadSize());
+        logger.error("Uploaded file was too large", exception, loggedVars);
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).build();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -18,8 +18,8 @@ import uk.gov.companieshouse.api.model.filetransfer.AvStatusApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.filetransferservice.converter.MultipartFileToFileApiConverter;
+import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
 import uk.gov.companieshouse.filetransferservice.service.file.transfer.FileStorageStrategy;
-import uk.gov.companieshouse.filetransferservice.validation.InvalidMimeTypeException;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -89,6 +89,9 @@ public class FileTransferController {
         } catch (IOException e) {
             logger.error("Error uploading file", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Unable to upload file");
+        } catch (InvalidMimeTypeException e) {
+            logger.error("File was uploaded with an invalid mime type", e);
+            return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(e.getMessage());
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -65,23 +65,6 @@ public class FileTransferController {
         }
     }
 
-    /**
-     * Gets the file extension of the specified file name. For example, if the file name is "document.pdf",
-     * the file extension returned is "pdf". If the file name does not contain a file extension, an empty string
-     * is returned.
-     *
-     * @param fileName the name of the file
-     * @return the file extension
-     */
-    private String getFileExtension(String fileName) {
-        String[] parts = fileName.split("\\.");
-        if (parts.length > 1) {
-            return parts[parts.length - 1];
-        } else {
-            return "";
-        }
-    }
-
 
     /**
      * Handles the request to retrieve a file from S3
@@ -97,7 +80,7 @@ public class FileTransferController {
             logger.errorContext(fileId,
                     "No file with id found",
                     null,
-                    Map.of("fileId", fileId));
+                    new HashMap<>(Map.of("fileId", fileId)));
             return ResponseEntity.notFound().build();
         }
 
@@ -106,7 +89,7 @@ public class FileTransferController {
         if (fileDetails.getAvStatusApi() != AvStatusApi.CLEAN) {
             logger.infoContext(fileId,
                     "Request for file denied as AV status is not clean",
-                    Map.of("fileId", fileId));
+                    new HashMap<>(Map.of("fileId", fileId)));
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -127,7 +110,9 @@ public class FileTransferController {
                 .build());
         headers.setContentLength(data.length);
 
-        return new ResponseEntity<>(data, headers, HttpStatus.OK);
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(data);
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,14 +76,14 @@ public class FileTransferController {
             if (ALLOWED_MIME_TYPES.contains(mimeType)) {
                 FileApi fileApi = new FileApi(fileName, data, mimeType, size, extension);
                 String fileId = fileStorageStrategy.save(fileApi);
-                logger.infoContext(fileId, "Created file", Map.of("id", fileId));
+                logger.infoContext(fileId, "Created file", new HashMap<>(Map.of("id", fileId)));
                 return ResponseEntity.status(HttpStatus.CREATED).body(fileId);
             } else {
                 logger.error("Unable to upload file as it has an invalid mime type",
-                        Map.of("mime type",
+                        new HashMap<>(Map.of("mime type",
                                 mimeType != null ? mimeType : "No Mime type",
                                 "file name",
-                                fileName));
+                                fileName)));
                 return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body("Unsupported file type");
             }
         } catch (IOException e) {
@@ -184,7 +185,7 @@ public class FileTransferController {
     @DeleteMapping(path = "/{fileId}")
     public ResponseEntity<Void> delete(@PathVariable String fileId) {
         fileStorageStrategy.delete(fileId);
-        logger.infoContext(fileId, "Deleted file", Map.of("fileId", fileId));
+        logger.infoContext(fileId, "Deleted file", new HashMap<>(Map.of("fileId", fileId)));
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverter.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverter.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.filetransferservice.converter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.model.filetransfer.FileApi;
+import uk.gov.companieshouse.filetransferservice.validation.InvalidMimeTypeException;
+import uk.gov.companieshouse.filetransferservice.validation.UploadedFileValidator;
+
+import java.io.IOException;
+import java.util.Optional;
+
+
+@Component
+public class MultipartFileToFileApiConverter {
+    private final UploadedFileValidator uploadedFileValidator;
+
+    @Autowired
+    public MultipartFileToFileApiConverter(UploadedFileValidator uploadedFileValidator) {
+        this.uploadedFileValidator = uploadedFileValidator;
+    }
+
+    @NonNull
+    public FileApi convert(@NonNull MultipartFile multipartFile) throws InvalidMimeTypeException, IOException {
+        uploadedFileValidator.validate(multipartFile);
+
+        byte[] data = multipartFile.getBytes();
+        String fileName = Optional.ofNullable(multipartFile.getOriginalFilename()).orElse("");
+        String mimeType = multipartFile.getContentType();
+        int size = (int) multipartFile.getSize();
+        String extension = getFileExtension(fileName);
+        return new FileApi(fileName, data, mimeType, size, extension);
+    }
+
+    private String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex == -1 || dotIndex == fileName.length() - 1) {
+            return "";
+        }
+        return fileName.substring(dotIndex + 1);
+    }
+}
+

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverter.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverter.java
@@ -5,7 +5,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
-import uk.gov.companieshouse.filetransferservice.validation.InvalidMimeTypeException;
+import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
 import uk.gov.companieshouse.filetransferservice.validation.UploadedFileValidator;
 
 import java.io.IOException;

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/exception/FileNotCleanException.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/exception/FileNotCleanException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.filetransferservice.exception;
+
+import uk.gov.companieshouse.api.model.filetransfer.AvStatusApi;
+
+public class FileNotCleanException extends Exception {
+    private final AvStatusApi avStatus;
+
+    public FileNotCleanException(AvStatusApi avStatus) {
+        this.avStatus = avStatus;
+    }
+
+    public AvStatusApi getAvStatus() {
+        return avStatus;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/exception/FileNotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/exception/FileNotFoundException.java
@@ -1,0 +1,13 @@
+package uk.gov.companieshouse.filetransferservice.exception;
+
+public class FileNotFoundException extends Exception {
+    private final String fileId;
+
+    public FileNotFoundException(String fileId) {
+        this.fileId = fileId;
+    }
+
+    public String getFileId() {
+        return fileId;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/exception/InvalidMimeTypeException.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/exception/InvalidMimeTypeException.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.filetransferservice.validation;
+package uk.gov.companieshouse.filetransferservice.exception;
 
 public class InvalidMimeTypeException extends Exception {
     private final String mimeType;

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/security/LoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/security/LoggingInterceptor.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.filetransferservice.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.util.RequestLogger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This class manages the logging of the start request and end request.
+ */
+@Component
+public class LoggingInterceptor extends HandlerInterceptorAdapter implements RequestLogger {
+    private final Logger logger;
+
+    /**
+     * Sets the logger used to log out request information.
+     *
+     * @param logger the configured logger
+     */
+    @Autowired
+    public LoggingInterceptor(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean preHandle(@NonNull HttpServletRequest request,
+                             @NonNull HttpServletResponse response,
+                             @NonNull Object handler) {
+        logStartRequestProcessing(request, logger);
+        return true;
+    }
+
+    @Override
+    public void postHandle(@NonNull HttpServletRequest request,
+                           @NonNull HttpServletResponse response,
+                           @NonNull Object handler,
+                           ModelAndView modelAndView) {
+        logEndRequestProcessing(request, response, logger);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/file/transfer/S3FileStorage.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/file/transfer/S3FileStorage.java
@@ -19,7 +19,7 @@ public class S3FileStorage implements FileStorageStrategy {
      */
     @Override
     public String save(FileApi file) {
-        return null;
+        return "";
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/validation/InvalidMimeTypeException.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/validation/InvalidMimeTypeException.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.filetransferservice.validation;
+
+public class InvalidMimeTypeException extends Exception {
+    private final String mimeType;
+
+    public InvalidMimeTypeException(String mimeType) {
+        super(createMessage(mimeType));
+        this.mimeType = mimeType;
+    }
+
+    private static String createMessage(String mimeType) {
+        return String.format("Mime type [%s] is not a valid mime type", mimeType);
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+}
+

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidator.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidator.java
@@ -1,0 +1,40 @@
+package uk.gov.companieshouse.filetransferservice.validation;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class UploadedFileValidator {
+    public static final List<String> ALLOWED_MIME_TYPES = Arrays.asList(
+            "text/plain",
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "application/pdf",
+            "text/csv",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-excel",
+            "image/gif",
+            "application/x-rar-compressed",
+            "application/x-tar",
+            "application/x-7z-compressed",
+            "application/xhtml+xml",
+            "application/zip"
+    );
+
+    private boolean isValidMimeType(final String mimeType) {
+        return ALLOWED_MIME_TYPES.contains(mimeType);
+    }
+
+    public void validate(MultipartFile file) throws InvalidMimeTypeException {
+        var contentType = file.getContentType();
+        if (!isValidMimeType(contentType)) {
+            throw new InvalidMimeTypeException(contentType);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidator.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidator.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.filetransferservice.validation;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 # suppress inspection "UnusedProperty" for whole file
 application.namespace=file-transfer-service
+spring.servlet.multipart.max-file-size=${MAX_FILE_SIZE:300MB}

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileSizeExceptionAdviceTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileSizeExceptionAdviceTest.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.filetransferservice.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+public class FileSizeExceptionAdviceTest {
+
+    @Mock
+    private Logger mockLogger;
+
+    private FileSizeExceptionAdvice advice;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        advice = new FileSizeExceptionAdvice(mockLogger);
+    }
+
+    @Test
+    void testHandleFileTooLarge() {
+        MaxUploadSizeExceededException exception = new MaxUploadSizeExceededException(1024L);
+        ResponseEntity<?> response = advice.handleFileTooLarge(exception);
+        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, response.getStatusCode());
+
+        verify(mockLogger).error(
+                "Uploaded file was too large",
+                exception,
+                new HashMap<String, Object>() {{
+                    put("maxFileSize", 1024L);
+                }}
+        );
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
@@ -1,8 +1,11 @@
 package uk.gov.companieshouse.filetransferservice.controller;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,7 +25,9 @@ import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.model.filetransfer.AvStatusApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
+import uk.gov.companieshouse.filetransferservice.converter.MultipartFileToFileApiConverter;
 import uk.gov.companieshouse.filetransferservice.service.file.transfer.FileStorageStrategy;
+import uk.gov.companieshouse.filetransferservice.validation.InvalidMimeTypeException;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;
@@ -31,6 +36,8 @@ import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 public class FileTransferControllerTest {
+    @Mock
+    private MultipartFileToFileApiConverter converter;
 
     @Mock
     private Logger logger;
@@ -43,7 +50,7 @@ public class FileTransferControllerTest {
 
     @Test
     @DisplayName("Test uploading a file with allowed MIME type")
-    public void testUploadFileWithAllowedMimeType() {
+    public void testUploadFileWithAllowedMimeType() throws IOException, InvalidMimeTypeException {
         MultipartFile mockFile = new MockMultipartFile("test.pdf",
                 "test.pdf",
                 "application/pdf",
@@ -53,32 +60,39 @@ public class FileTransferControllerTest {
                 "application/pdf",
                 4,
                 "pdf");
+
+        when(converter.convert(mockFile)).thenReturn(mockFileApi);
         when(fileStorageStrategy.save(mockFileApi)).thenReturn("123");
 
         ResponseEntity<String> response = fileTransferController.upload(mockFile);
 
-        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("123", response.getBody());
         verify(fileStorageStrategy, times(1)).save(mockFileApi);
     }
 
     @Test
     @DisplayName("Test uploading a file with unsupported MIME type")
-    public void testUploadFileWithUnsupportedMimeType() {
-        MultipartFile mockFile = new MockMultipartFile("test.txt", "test".getBytes());
+    public void testUploadFileWithUnsupportedMimeType() throws InvalidMimeTypeException, IOException {
+        MultipartFile mockFile = new MockMultipartFile("file",
+                "test.txt",
+                "invalid",
+                "test".getBytes());
+
+        doThrow(new InvalidMimeTypeException(mockFile.getContentType())).when(converter).convert(mockFile);
 
         ResponseEntity<String> response = fileTransferController.upload(mockFile);
 
         assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE, response.getStatusCode());
-        assertEquals("Unsupported file type", response.getBody());
+        assertThat(response.getBody(), containsString("is not a valid mime type"));
         verify(fileStorageStrategy, times(0)).save(any());
     }
 
     @Test
     @DisplayName("Test uploading a file with IOException")
-    public void testUploadFileWithIOException() throws IOException {
+    public void testUploadFileWithIOException() throws IOException, InvalidMimeTypeException {
         MultipartFile mockFile = mock(MultipartFile.class);
-        when(mockFile.getBytes()).thenThrow(new IOException());
+        when(converter.convert(mockFile)).thenThrow(new IOException());
 
         ResponseEntity<String> response = fileTransferController.upload(mockFile);
 

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
@@ -26,8 +26,8 @@ import uk.gov.companieshouse.api.model.filetransfer.AvStatusApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.filetransferservice.converter.MultipartFileToFileApiConverter;
+import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
 import uk.gov.companieshouse.filetransferservice.service.file.transfer.FileStorageStrategy;
-import uk.gov.companieshouse.filetransferservice.validation.InvalidMimeTypeException;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.io.IOException;

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverterTest.java
@@ -12,7 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
-import uk.gov.companieshouse.filetransferservice.validation.InvalidMimeTypeException;
+import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
 import uk.gov.companieshouse.filetransferservice.validation.UploadedFileValidator;
 
 import java.io.IOException;

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverterTest.java
@@ -1,0 +1,57 @@
+package uk.gov.companieshouse.filetransferservice.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.model.filetransfer.FileApi;
+import uk.gov.companieshouse.filetransferservice.validation.InvalidMimeTypeException;
+import uk.gov.companieshouse.filetransferservice.validation.UploadedFileValidator;
+
+import java.io.IOException;
+
+@ExtendWith(MockitoExtension.class)
+class MultipartFileToFileApiConverterTest {
+    @Mock
+    UploadedFileValidator fileValidator;
+
+    private MultipartFileToFileApiConverter fileApiConverter;
+
+    @BeforeEach
+    void setUp() {
+        fileApiConverter = new MultipartFileToFileApiConverter(fileValidator);
+
+        try {
+            doNothing().when(fileValidator).validate(any(MultipartFile.class));
+        } catch (InvalidMimeTypeException e) {
+            // Impossible
+        }
+    }
+
+    @Test
+    void testConvertMultipartFile() throws IOException, InvalidMimeTypeException {
+        // Given
+        byte[] bytes = "Hello, World!".getBytes();
+        String filename = "example.txt";
+        String contentType = "text/plain";
+        MultipartFile multipartFile = new MockMultipartFile(filename, filename, contentType, bytes);
+
+        // When
+        FileApi result = fileApiConverter.convert(multipartFile);
+
+        // Then
+        assertEquals(filename, result.getFileName());
+        assertEquals(bytes, result.getBody());
+        assertEquals(contentType, result.getMimeType());
+        assertEquals(bytes.length, result.getSize());
+        assertEquals("txt", result.getExtension());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidatorTest.java
@@ -1,0 +1,110 @@
+package uk.gov.companieshouse.filetransferservice.validation;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+@ExtendWith(MockitoExtension.class)
+public class UploadedFileValidatorTest {
+    private static final List<String> ALL_MIME_TYPES = Arrays.asList(
+            "text/plain",
+            "text/html",
+            "text/xml",
+            "text/css",
+            "text/csv",
+            "text/calendar",
+            "text/markdown",
+            "image/gif",
+            "image/jpeg",
+            "image/png",
+            "image/bmp",
+            "image/svg+xml",
+            "image/tiff",
+            "image/webp",
+            "audio/midi",
+            "audio/mpeg",
+            "audio/webm",
+            "audio/ogg",
+            "audio/wav",
+            "video/mp4",
+            "video/mpeg",
+            "video/ogg",
+            "video/quicktime",
+            "video/webm",
+            "application/javascript",
+            "application/json",
+            "application/ld+json",
+            "application/msword",
+            "application/octet-stream",
+            "application/pdf",
+            "application/vnd.ms-powerpoint",
+            "application/vnd.ms-excel",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/x-rar-compressed",
+            "application/x-tar",
+            "application/x-bzip2",
+            "application/x-7z-compressed",
+            "application/zip",
+            "application/x-zip-compressed",
+            "application/xml",
+            "application/atom+xml",
+            "application/rss+xml"
+    );
+
+
+    @InjectMocks
+    private UploadedFileValidator validator;
+
+    public static Stream<Arguments> getAllowedMimeTypes() {
+        return UploadedFileValidator.ALLOWED_MIME_TYPES.stream()
+                .map(Arguments::of);
+    }
+
+    public static Stream<Arguments> getDisallowedMimeTypes() {
+        return ALL_MIME_TYPES.stream()
+                .filter(t -> !UploadedFileValidator.ALLOWED_MIME_TYPES.contains(t))
+                .map(Arguments::of);
+    }
+
+    private static MockMultipartFile createMockMultipartFile(final String mimeType) {
+        return new MockMultipartFile("file",
+                "filename.jpg",
+                mimeType,
+                "file content".getBytes());
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("getAllowedMimeTypes")
+    @DisplayName("Given a MultipartFile with a valid mime type, when validated by the validator, then no exception should be thrown")
+    void testAllowedMimeTypePassesValidation(String mimeType) throws InvalidMimeTypeException {
+        // Create a mock MultipartFile object with the given mime type
+        MultipartFile file = createMockMultipartFile(mimeType);
+
+        validator.validate(file);
+    }
+
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("getDisallowedMimeTypes")
+    @DisplayName("Given a MultipartFile with an in-valid mime type, when validated by the validator, an exception should be thrown")
+    void testDisallowedMimeTypeThrowsException(String mimeType) {
+        // Create a mock MultipartFile object with the given mime type
+        MultipartFile file = createMockMultipartFile(mimeType);
+
+        // Verify that an exception is thrown when the validator is used to validate the file
+        assertThrows(InvalidMimeTypeException.class, () -> validator.validate(file));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidatorTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
- Adds a missed requirement in [BI-12499](https://companieshouse.atlassian.net/browse/BI-12499) to limit the upload size. 
- Added a type converter to convert `MultipartFile` to `FileApi` simplifying the logic of the controller and ahering to the single respoisbility principle.
- Added validator to validate mime type of the uploaded file.
- Refactored the error handling in the controller to be exception based.

[BI-12499]: https://companieshouse.atlassian.net/browse/BI-12499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ