### PR TITLE
Add json endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <!-- internal -->
         <structured-logging.version>1.9.14</structured-logging.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.226</private-api-sdk-java.version>
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         <aws-java-sdk.version>1.12.343</aws-java-sdk.version>
         <api-helper-java.version>1.4.3</api-helper-java.version>
@@ -149,7 +149,7 @@
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>api-sdk-java</artifactId>
+            <artifactId>private-api-sdk-java</artifactId>
             <version>${private-api-sdk-java.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <!-- internal -->
         <structured-logging.version>1.9.14</structured-logging.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
-        <api-sdk-java.version>4.3.26</api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         <aws-java-sdk.version>1.12.343</aws-java-sdk.version>
         <api-helper-java.version>1.4.3</api-helper-java.version>
@@ -46,8 +46,8 @@
         <dependencies>
             <dependency>
                 <groupId>uk.gov.companieshouse</groupId>
-                <artifactId>api-sdk-java</artifactId>
-                <version>${api-sdk-java.version}</version>
+                <artifactId>private-api-sdk-java</artifactId>
+                <version>${private-api-sdk-java.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-java</artifactId>
-            <version>${api-sdk-java.version}</version>
+            <version>${private-api-sdk-java.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverter.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverter.java
@@ -1,12 +1,9 @@
 package uk.gov.companieshouse.filetransferservice.converter;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
-import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
-import uk.gov.companieshouse.filetransferservice.validation.UploadedFileValidator;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -14,17 +11,9 @@ import java.util.Optional;
 
 @Component
 public class MultipartFileToFileApiConverter {
-    private final UploadedFileValidator uploadedFileValidator;
-
-    @Autowired
-    public MultipartFileToFileApiConverter(UploadedFileValidator uploadedFileValidator) {
-        this.uploadedFileValidator = uploadedFileValidator;
-    }
 
     @NonNull
-    public FileApi convert(@NonNull MultipartFile multipartFile) throws InvalidMimeTypeException, IOException {
-        uploadedFileValidator.validate(multipartFile);
-
+    public FileApi convert(@NonNull MultipartFile multipartFile) throws IOException {
         byte[] data = multipartFile.getBytes();
         String fileName = Optional.ofNullable(multipartFile.getOriginalFilename()).orElse("");
         String mimeType = multipartFile.getContentType();

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/errors/ErrorResponseBuilder.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/errors/ErrorResponseBuilder.java
@@ -42,7 +42,7 @@ public class ErrorResponseBuilder {
         return withError(new ApiError(error, location, locationType, type));
     }
 
-    public ResponseEntity<?> build() {
+    public ResponseEntity<ApiErrorResponse> build() {
         var errResponse = new ApiErrorResponse();
         errResponse.setErrors(errors);
         return ResponseEntity.status(this.status).body(errResponse);

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/errors/ErrorResponseBuilder.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/errors/ErrorResponseBuilder.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.filetransferservice.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.companieshouse.api.error.ApiError;
+import uk.gov.companieshouse.api.error.ApiErrorResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ErrorResponseBuilder {
+    private final List<ApiError> errors;
+    private HttpStatus status;
+
+    public ErrorResponseBuilder() {
+        this.errors = new ArrayList<>();
+    }
+
+    public static ErrorResponseBuilder status(HttpStatus status) {
+        var builder = new ErrorResponseBuilder();
+
+        if (!status.isError()) {
+            throw new IllegalArgumentException(String.format(
+                    "Status to ApiErrorResponse must be an error status. %d (%s) is not.",
+                    status.value(),
+                    status));
+        }
+
+        builder.status = status;
+        return builder;
+    }
+
+    public ErrorResponseBuilder withError(ApiError error) {
+        this.errors.add(error);
+        return this;
+    }
+
+    public ErrorResponseBuilder withError(String error,
+                                          String location,
+                                          String locationType,
+                                          String type) {
+        return withError(new ApiError(error, location, locationType, type));
+    }
+
+    public ResponseEntity<?> build() {
+        var errResponse = new ApiErrorResponse();
+        errResponse.setErrors(errors);
+        return ResponseEntity.status(this.status).body(errResponse);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/exception/FileNotCleanException.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/exception/FileNotCleanException.java
@@ -4,12 +4,18 @@ import uk.gov.companieshouse.api.model.filetransfer.AvStatusApi;
 
 public class FileNotCleanException extends Exception {
     private final AvStatusApi avStatus;
+    private final String fileId;
 
-    public FileNotCleanException(AvStatusApi avStatus) {
+    public FileNotCleanException(AvStatusApi avStatus, String fileId) {
         this.avStatus = avStatus;
+        this.fileId = fileId;
     }
 
     public AvStatusApi getAvStatus() {
         return avStatus;
+    }
+
+    public String getFileId() {
+        return fileId;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidator.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidator.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.filetransferservice.validation;
 
 import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
 
 import java.util.Arrays;
@@ -32,8 +32,8 @@ public class UploadedFileValidator {
         return ALLOWED_MIME_TYPES.contains(mimeType);
     }
 
-    public void validate(MultipartFile file) throws InvalidMimeTypeException {
-        var contentType = file.getContentType();
+    public void validate(FileApi file) throws InvalidMimeTypeException {
+        var contentType = file.getMimeType();
         if (!isValidMimeType(contentType)) {
             throw new InvalidMimeTypeException(contentType);
         }

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/converter/MultipartFileToFileApiConverterTest.java
@@ -1,42 +1,28 @@
 package uk.gov.companieshouse.filetransferservice.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.companieshouse.api.model.filetransfer.FileApi;
-import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
-import uk.gov.companieshouse.filetransferservice.validation.UploadedFileValidator;
 
 import java.io.IOException;
 
 @ExtendWith(MockitoExtension.class)
 class MultipartFileToFileApiConverterTest {
-    @Mock
-    UploadedFileValidator fileValidator;
-
     private MultipartFileToFileApiConverter fileApiConverter;
 
     @BeforeEach
     void setUp() {
-        fileApiConverter = new MultipartFileToFileApiConverter(fileValidator);
-
-        try {
-            doNothing().when(fileValidator).validate(any(MultipartFile.class));
-        } catch (InvalidMimeTypeException e) {
-            // Impossible
-        }
+        fileApiConverter = new MultipartFileToFileApiConverter();
     }
 
     @Test
-    void testConvertMultipartFile() throws IOException, InvalidMimeTypeException {
+    void testConvertMultipartFile() throws IOException {
         // Given
         byte[] bytes = "Hello, World!".getBytes();
         String filename = "example.txt";

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidatorTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
+import uk.gov.companieshouse.api.model.filetransfer.FileApi;
 import uk.gov.companieshouse.filetransferservice.exception.InvalidMimeTypeException;
 
 import java.util.Arrays;
@@ -81,11 +80,9 @@ public class UploadedFileValidatorTest {
                 .map(Arguments::of);
     }
 
-    private static MockMultipartFile createMockMultipartFile(final String mimeType) {
-        return new MockMultipartFile("file",
-                "filename.jpg",
-                mimeType,
-                "file content".getBytes());
+    private static FileApi createMockMultipartFile(final String mimeType) {
+        byte[] content = "file content".getBytes();
+        return new FileApi("filename.jpg", content, mimeType, content.length, "jpg");
     }
 
     @ParameterizedTest(name = "{index} {0}")
@@ -93,7 +90,7 @@ public class UploadedFileValidatorTest {
     @DisplayName("Given a MultipartFile with a valid mime type, when validated by the validator, then no exception should be thrown")
     void testAllowedMimeTypePassesValidation(String mimeType) throws InvalidMimeTypeException {
         // Create a mock MultipartFile object with the given mime type
-        MultipartFile file = createMockMultipartFile(mimeType);
+        FileApi file = createMockMultipartFile(mimeType);
 
         validator.validate(file);
     }
@@ -103,7 +100,7 @@ public class UploadedFileValidatorTest {
     @DisplayName("Given a MultipartFile with an in-valid mime type, when validated by the validator, an exception should be thrown")
     void testDisallowedMimeTypeThrowsException(String mimeType) {
         // Create a mock MultipartFile object with the given mime type
-        MultipartFile file = createMockMultipartFile(mimeType);
+        FileApi file = createMockMultipartFile(mimeType);
 
         // Verify that an exception is thrown when the validator is used to validate the file
         assertThrows(InvalidMimeTypeException.class, () -> validator.validate(file));


### PR DESCRIPTION
- Adds a JSON endpoint so that it is compatible with the `api-sdk-java` library.
- Adds exception handlers so that endpoint methods can be strongly typed intead of using wildcard generics.
- Switches to the `private-sdk-java` from `api-sdk-java`