### PR TITLE
Store filename as metadata in S3

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.filetransferservice.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
@@ -36,10 +38,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-
 @Controller
-@RequestMapping(path = "/file-transfer-service")
+@RequestMapping(path = "${service.path.prefix}")
 public class FileTransferController {
     public static final String FILE_ID_KEY = "fileId";
 

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.filetransferservice.service.impl;
 
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
@@ -22,8 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 @Component
 public class AmazonFileTransferImpl implements AmazonFileTransfer {
@@ -147,6 +147,13 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
         } else {
             throw new SdkClientException("meta data does not contain Content-Type");
         }
+
+        // Add all other metadata key value pairs to user meta data
+        metaData.forEach((k, v) -> {
+            if (!k.equalsIgnoreCase(CONTENT_TYPE)) {
+                omd.addUserMetadata(k, v);
+            }
+        });
 
         return omd;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ aws.accessKeyId=${AWS_ACCESS_KEY_ID}
 aws.bucketName=${FILE_BUCKET_NAME}
 aws.protocol=https
 aws.s3PathPrefix=s3://
+service.path.prefix=/file-transfer-service

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImplTest.java
@@ -1,5 +1,16 @@
 package uk.gov.companieshouse.filetransferservice.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.filetransferservice.service.file.transfer.S3FileStorage.FILENAME_METADATA_KEY;
+
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
@@ -25,17 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 class AmazonFileTransferImplTest {
+    private static final String TEST_FILE_NAME = "file.pdf";
     private AmazonFileTransferImpl amazonFileTransfer;
     private AWSServiceProperties properties;
     private GetObjectTaggingResult taggingResult;
@@ -361,6 +363,7 @@ class AmazonFileTransferImplTest {
     private Map<String, String> createValidMetaData() {
         return new HashMap<>() {{
             put("Content-Type", "application/pdf");
+            put(FILENAME_METADATA_KEY, TEST_FILE_NAME);
         }};
     }
 


### PR DESCRIPTION
Added code that saves the file name as metadata in S3. This is required for [BI-12390](https://companieshouse.atlassian.net/browse/BI-12390) as the filename needs to be returned to be rendered on the results page. 
This PR also populates the links attribute on the file details.