### PR TITLE
Add missing mesos files

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,0 +1,5 @@
+app_name: file-transfer-service
+group: api
+weight: 900
+routes:
+  1: /file-transfer-service*

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Start script for file-transfer-service
+
+APP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+PORT="$1"
+CONFIG_URL="$2"
+ENVIRONMENT="$3"
+APP_NAME="$4"
+
+source /etc/profile
+
+echo "Downloading environment from: ${CONFIG_URL}/${ENVIRONMENT}/${APP_NAME}"
+wget -O "${APP_DIR}/private_env" "${CONFIG_URL}/${ENVIRONMENT}/private_env"
+wget -O "${APP_DIR}/global_env" "${CONFIG_URL}/${ENVIRONMENT}/global_env"
+wget -O "${APP_DIR}/app_env" "${CONFIG_URL}/${ENVIRONMENT}/${APP_NAME}/env"
+source "${APP_DIR}/private_env"
+source "${APP_DIR}/global_env"
+source "${APP_DIR}/app_env"
+
+exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/file-transfer-service.jar"


### PR DESCRIPTION
- Needs a `start.sh` file so mesos can run it.
- Needs `routes.yaml` so that HAPROXY can be configured with the url paths.