### PR TITLE
Close s3 object stream after reading

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImpl.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 public class AmazonFileTransferImpl implements AmazonFileTransfer {
 
     private static final String S3_PATH_PREFIX = "s3://";
-    private static final String ERROR_KEY = "error";
 
     private final AmazonS3 s3Client;
     private final AWSServiceProperties properties;
@@ -54,6 +53,19 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
     }
 
     /**
+     * Reads the body of an S3 object and ensures it is closed correctly afterwards.
+     *
+     * @param s3Object the object to read
+     * @return the body of the object as an array of bytes
+     * @throws IOException if the stream cannot be closed
+     */
+    private static byte[] readS3Object(S3Object s3Object) throws IOException {
+        try (InputStream stream = s3Object.getObjectContent()) {
+            return IOUtils.toByteArray(stream);
+        }
+    }
+
+    /**
      * Download a file from S3
      *
      * @return String
@@ -65,9 +77,10 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
             S3Object s3Object = getObjectInS3(fileId);
             return Optional.ofNullable(readS3Object(s3Object));
         } catch (Exception e) {
-            logger.error(e, new HashMap<>() {{
-                put(ERROR_KEY, "Unable to fetch file from S3");
+            logger.errorContext(fileId, "Unable to fetch file from S3", e, new HashMap<>() {{
+                put("fileId", fileId);
             }});
+
             return Optional.empty();
         }
     }
@@ -83,8 +96,8 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
             validateS3Details();
             return Optional.ofNullable(s3Client.getObject(new GetObjectRequest(properties.getBucketName(), fileId)));
         } catch (Exception e) {
-            logger.error(e, new HashMap<>() {{
-                put(ERROR_KEY, "Unable to fetch object from S3");
+            logger.errorContext(fileId, "Unable to fetch object from S3", e, new HashMap<>() {{
+                put("fileId", fileId);
             }});
             return Optional.empty();
         }
@@ -101,8 +114,8 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
             validateS3Details();
             return Optional.ofNullable(s3Client.getObjectTagging(new GetObjectTaggingRequest(properties.getBucketName(), fileId)).getTagSet());
         } catch (Exception e) {
-            logger.error(e, new HashMap<>() {{
-                put(ERROR_KEY, "Unable to fetch file tags from S3");
+            logger.errorContext(fileId, "Unable to fetch file tags from S3", e, new HashMap<>() {{
+                put("fileId", fileId);
             }});
             return Optional.empty();
         }

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImpl.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.filetransferservice.model.AWSServiceProperties;
 import uk.gov.companieshouse.filetransferservice.service.AmazonFileTransfer;
 import uk.gov.companieshouse.logging.Logger;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -62,7 +63,7 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
         try {
             validateS3Details();
             S3Object s3Object = getObjectInS3(fileId);
-            return Optional.ofNullable(IOUtils.toByteArray(s3Object.getObjectContent()));
+            return Optional.ofNullable(readS3Object(s3Object));
         } catch (Exception e) {
             logger.error(e, new HashMap<>() {{
                 put(ERROR_KEY, "Unable to fetch file from S3");


### PR DESCRIPTION
When reading the S3Object the input stream wasn't being closed leading to the connection pool becoming full.
This PR uses a try-with block to auto-close the input stream after reading. This should free-up the conncton and prevent the connection pool filling up.