### PR TITLE
Close unused connections

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 # suppress inspection "UnusedProperty" for whole file
 application.namespace=file-transfer-service
 spring.servlet.multipart.max-file-size=${MAX_FILE_SIZE:300MB}
+spring.servlet.multipart.max-request-size=${MAX_FILE_SIZE:300MB}
 ######### AWS S3 Credentials #########
 aws.region=${AWS_REGION}
 aws.secretAccessKey=${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
Along with the input stream, the S3 object also needs to be closed. 
This PR puts the S3 object in a try-with block that causes the S3Object and S3ObjectInputStream to be closed after being read.