### PR TITLE
Add xml to allowed mime types

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfiguration.java
@@ -1,9 +1,8 @@
 package uk.gov.companieshouse.filetransferservice.config;
 
+import static com.amazonaws.util.StringUtils.isNullOrEmpty;
+
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,8 +12,6 @@ import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.filetransferservice.model.AWSServiceProperties;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-
-import static com.amazonaws.util.StringUtils.isNullOrEmpty;
 
 
 @Configuration
@@ -54,25 +51,46 @@ public class ApplicationConfiguration {
     }
 
     /**
-     * Creates the amazon s3 client builder.
+     * Creates and configures a builder for creating AmazonS3 client instances.
+     * <p>
+     * This bean uses the standard configuration for the AmazonS3ClientBuilder which
+     * includes region and credential configuration that auto-detects the AWS settings
+     * based on the environment.
      *
-     * @return amazon s3 client builder
+     * @return a configured instance of AmazonS3ClientBuilder ready for further customization
      */
     @Bean
     public AmazonS3ClientBuilder amazonS3ClientBuilder() {
         return AmazonS3ClientBuilder.standard();
     }
 
+
     /**
-     * Creates the s3 client.
+     * Creates an Amazon S3 client using the DefaultAWSCredentialsProviderChain. This client
+     * configuration will include any proxy settings if they are provided. Proxy settings
+     * and region information are extracted from the supplied AWSServiceProperties.
+     * <p>
+     * The DefaultAWSCredentialsProviderChain searches for credentials in the following order:
+     * - Environment Variables (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)
+     * - Java System Properties (aws.accessKeyId and aws.secretKey)
+     * - Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs
+     * - Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+     *   environment variable is set and the security manager has permission to access the variable
+     * - Instance profile credentials delivered through the Amazon EC2 metadata service
+     * - Credentials from the AWS SSO login flow after being exported into the environment using the AWS CLI.
+     *   Example: Use `eval "$(aws configure export-credentials --profile dev --format env)"` to set the required
+     *   environment variables after an SSO login.
      *
-     * @param properties
-     * @param clientConfiguration
-     * @param amazonS3ClientBuilder
-     * @return s3 client
+     * @param properties          The AWSServiceProperties object containing the region, proxy host, and proxy port.
+     * @param clientConfiguration The ClientConfiguration object that may be pre-configured with proxy
+     *                            settings and other client parameters.
+     * @param amazonS3ClientBuilder The AmazonS3ClientBuilder object to be used for creating the client.
+     * @return An initialized AmazonS3 client that is ready to be used to communicate with the S3 service.
      */
     @Bean
-    public AmazonS3 getAmazonS3Client(AWSServiceProperties properties, ClientConfiguration clientConfiguration, AmazonS3ClientBuilder amazonS3ClientBuilder) {
+    public AmazonS3 getAmazonS3Client(AWSServiceProperties properties,
+                                      ClientConfiguration clientConfiguration,
+                                      AmazonS3ClientBuilder amazonS3ClientBuilder) {
         String httpProxyHostName = properties.getProxyHost();
         if (!isNullOrEmpty(httpProxyHostName)) {
             clientConfiguration.setProxyHost(httpProxyHostName);
@@ -83,10 +101,7 @@ public class ApplicationConfiguration {
             clientConfiguration.setProxyPort(httpProxyPort);
         }
 
-        AWSCredentials credentials = new BasicAWSCredentials(properties.getAccessKeyId(), properties.getSecretAccessKey());
-
         return amazonS3ClientBuilder
-                .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withClientConfiguration(clientConfiguration)
                 .withRegion(properties.getRegion())
                 .build();

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/model/AWSServiceProperties.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/model/AWSServiceProperties.java
@@ -13,12 +13,6 @@ public class AWSServiceProperties {
     private String region;
 
     @NotBlank
-    private String secretAccessKey;
-
-    @NotBlank
-    private String accessKeyId;
-
-    @NotBlank
     private String bucketName;
 
     @NotBlank
@@ -37,22 +31,6 @@ public class AWSServiceProperties {
 
     public void setRegion(String region) {
         this.region = region;
-    }
-
-    public String getSecretAccessKey() {
-        return secretAccessKey;
-    }
-
-    public void setSecretAccessKey(String secretAccessKey) {
-        this.secretAccessKey = secretAccessKey;
-    }
-
-    public String getAccessKeyId() {
-        return accessKeyId;
-    }
-
-    public void setAccessKeyId(String accessKeyId) {
-        this.accessKeyId = accessKeyId;
     }
 
     public String getBucketName() {

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidator.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/validation/UploadedFileValidator.java
@@ -17,6 +17,7 @@ public class UploadedFileValidator {
             "application/pdf",
             "text/csv",
             "text/html",
+            "text/xml",
             "application/msword",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfigurationTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/config/ApplicationConfigurationTest.java
@@ -68,8 +68,6 @@ class ApplicationConfigurationTest {
         AmazonS3 actual = undertest.getAmazonS3Client(properties, clientConfiguration, builder);
 
         assertNotNull(actual);
-        verify(properties).getAccessKeyId();
-        verify(properties).getSecretAccessKey();
         verify(properties).getProxyPort();
         verify(properties).getRegion();
         verify(clientConfiguration, times(0)).setProxyHost(anyString());
@@ -86,8 +84,6 @@ class ApplicationConfigurationTest {
         AmazonS3 actual = undertest.getAmazonS3Client(properties, clientConfiguration, builder);
 
         assertNotNull(actual);
-        verify(properties).getAccessKeyId();
-        verify(properties).getSecretAccessKey();
         verify(properties).getProxyPort();
         verify(properties, atLeastOnce()).getRegion();
         verify(clientConfiguration).setProxyHost(anyString());
@@ -102,8 +98,6 @@ class ApplicationConfigurationTest {
     }
 
     private void createPropertyValueMocks(String proxyHost, Integer proxyPort) {
-        when(properties.getAccessKeyId()).thenReturn("anything");
-        when(properties.getSecretAccessKey()).thenReturn("anything");
         when(properties.getProxyHost()).thenReturn(proxyHost);
         when(properties.getProxyPort()).thenReturn(proxyPort);
         when(properties.getRegion()).thenReturn("anything");

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImplTest.java
@@ -70,8 +70,6 @@ class AmazonFileTransferImplTest {
     }
 
     private void mockConfigurationDetails() {
-        when(properties.getAccessKeyId()).thenReturn("");
-        when(properties.getSecretAccessKey()).thenReturn("");
         when(properties.getProtocol()).thenReturn("");
         when(properties.getBucketName()).thenReturn(S3_PATH);
         when(client.doesBucketExistV2(anyString())).thenReturn(true);


### PR DESCRIPTION
This PR adds `text\xml` to the list of allowed mime types.
It also removes the AWS basic credentials authentication.
This is because the default CredentialProviderChain includes this already.
It also includes a method to load aws SSO session variables alllowing for authorisation by export session credentials to the environment in the local environment.