### PR TITLE
CC-2094: Fix the AWS credential provider type

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/AwsSdkV2Config.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/AwsSdkV2Config.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.filetransferservice.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -20,7 +20,7 @@ class AwsSdkV2Config {
     S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.of(awsRegion))
-                .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
     }
 }


### PR DESCRIPTION
Fix a problem with AWS credential initialisation in CIDEV

[CC-2094](https://companieshouse.atlassian.net/browse/CC-2094)

[CC-2094]: https://companieshouse.atlassian.net/browse/CC-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ