### PR TITLE
Fix backwards-compatibility issues with earlier versions of private-sdk.

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/DefaultContentTypeFilter.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/DefaultContentTypeFilter.java
@@ -12,7 +12,19 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.logging.Logger;
 
+/**
+ * A filter that sets a default Content-Type of application/json for POST requests
+ * that do not have a Content-Type header set. This is intended for legacy clients
+ * that may not set the Content-Type header.
+ *
+ * This can be removed in future versions as it is a workaround for legacy clients.
+ * It is recommended that clients set the Content-Type header explicitly, and
+ * updating the private-api-sdk-java dependence > 4.0.315 should resolve this issue.
+ *
+ * @deprecated This filter is deprecated and will be removed in future versions.
+ */
 @Component
+@Deprecated(since = "0.2.16", forRemoval = true)
 public class DefaultContentTypeFilter implements Filter {
 
     private final Logger logger;

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/DefaultContentTypeFilter.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/DefaultContentTypeFilter.java
@@ -42,6 +42,8 @@ public class DefaultContentTypeFilter implements Filter {
 
         // If Content-Type is missing and it's a POST wrap it (for legacy/deprecated client
         if (request.getContentType() == null && ("POST".equalsIgnoreCase(request.getMethod()))) {
+            logger.debug("Content-Type not detected within POST request, to preserve legacy client functionality "
+                    + "we are wrapping request to set default Content-Type to application/json");
 
             HttpServletRequestWrapper wrapper = new HttpServletRequestWrapper(request) {
 

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/DefaultContentTypeFilter.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/DefaultContentTypeFilter.java
@@ -1,0 +1,57 @@
+package uk.gov.companieshouse.filetransferservice.config;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.logging.Logger;
+
+@Component
+public class DefaultContentTypeFilter implements Filter {
+
+    private final Logger logger;
+
+    public DefaultContentTypeFilter(final Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        logger.trace("doFilter(req, res, chain) method called.");
+
+        HttpServletRequest request = (HttpServletRequest) req;
+
+        // If Content-Type is missing and it's a POST wrap it (for legacy/deprecated client
+        if (request.getContentType() == null && ("POST".equalsIgnoreCase(request.getMethod()))) {
+
+            HttpServletRequestWrapper wrapper = new HttpServletRequestWrapper(request) {
+
+                @Override
+                public String getContentType() {
+                    return MediaType.APPLICATION_JSON_VALUE;
+                }
+
+                @Override
+                public String getHeader(String name) {
+                    if ("Content-Type".equalsIgnoreCase(name)) {
+                        return MediaType.APPLICATION_JSON_VALUE;
+                    }
+                    return super.getHeader(name);
+                }
+            };
+
+            chain.doFilter(wrapper, res);
+
+            return;
+        }
+
+        chain.doFilter(req, res);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebMvcConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/config/WebMvcConfig.java
@@ -5,6 +5,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.filetransferservice.logging.LoggingInterceptor;
+import uk.gov.companieshouse.logging.Logger;
 
 @Component
 public class WebMvcConfig implements WebMvcConfigurer {
@@ -13,14 +14,22 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final LoggingInterceptor loggingInterceptor;
     private final InternalUserInterceptor internalUserInterceptor;
+    private final Logger logger;
 
-    public WebMvcConfig(LoggingInterceptor loggingInterceptor, InternalUserInterceptor internalUserInterceptor) {
+    public WebMvcConfig(final LoggingInterceptor loggingInterceptor,
+            final InternalUserInterceptor internalUserInterceptor,
+            final Logger logger) {
+        logger.trace("WebMvcConfig constructor");
+
         this.loggingInterceptor = loggingInterceptor;
         this.internalUserInterceptor = internalUserInterceptor;
+        this.logger = logger;
     }
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
+        logger.trace("addInterceptors() method called.");
+
         registry.addInterceptor(loggingInterceptor).excludePathPatterns(HEALTH_CHECK_PATH);
         registry.addInterceptor(internalUserInterceptor).excludePathPatterns(HEALTH_CHECK_PATH);
     }

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -66,7 +66,17 @@ public class FileTransferController {
         this.bypassAv = bypassAv;
     }
 
-    @PostMapping(value = "/upload", consumes = "application/json", produces = "application/json")
+    /**
+     * Uploads the specified data (JSON payload) to the file transfer service. The uploaded file must be of a valid
+     * MIME type and this end-point is only available for legacy clients. This endpoint is deprecated and only used for
+     * earlier version of the private-api-sdk-java which did not originally support multipart/form-data.
+     *
+     * @param file the data to upload, represented as a JSON payload
+     * @return a ResponseEntity containing the ID of the uploaded file or an error message
+     * @throws InvalidMimeTypeException if the MIME type of the uploaded file is unsupported
+     * @throws IOException if an I/O error occurs during the upload process
+     */
+    @PostMapping(value = {"/", "/upload"}, consumes = "application/json", produces = "application/json")
     @Deprecated(since = "0.2.16", forRemoval = true)
     public ResponseEntity<IdApi> upload(@RequestBody uk.gov.companieshouse.filetransferservice.model.legacy.FileApi file)
             throws InvalidMimeTypeException, IOException {

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferController.java
@@ -66,12 +66,12 @@ public class FileTransferController {
         this.bypassAv = bypassAv;
     }
 
-    @PostMapping(value = "/upload", consumes = "application/json")
+    @PostMapping(value = "/upload", consumes = "application/json", produces = "application/json")
     @Deprecated(since = "0.2.16", forRemoval = true)
-    public ResponseEntity<IdApi> uploadJson(@RequestBody uk.gov.companieshouse.filetransferservice.model.legacy.FileApi file)
+    public ResponseEntity<IdApi> upload(@RequestBody uk.gov.companieshouse.filetransferservice.model.legacy.FileApi file)
             throws InvalidMimeTypeException, IOException {
 
-        logger.trace("uploadJson(file) method called.");
+        logger.trace("upload(json) method called.");
 
         mimeTypeValidator.validate(file.getMimeType());
 

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/converter/MetadataDecoder.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/converter/MetadataDecoder.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.filetransferservice.service.converter;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetadataDecoder implements Converter<String, String> {
+
+    @Override
+    public String convert(final String source) {
+        try {
+            // Check if the input is empty, or already URL encoded?
+            if(isEmpty(source) || !isUrlEncoded(source)) {
+                return source;
+            }
+
+            // Input is NOT URL encoded, so encode it.
+            return URLDecoder.decode(source, StandardCharsets.UTF_8);
+
+        } catch (Exception e) {
+            // Something went wrong during encoding, return the original source.
+            return source;
+        }
+    }
+
+    private boolean isUrlEncoded(final String input) {
+        // Decode and re-encode, then compare
+        String decoded = URLDecoder.decode(input, StandardCharsets.UTF_8);
+        String encoded = URLEncoder.encode(decoded, StandardCharsets.UTF_8).replace("+", "%20");
+
+        // Normalize input for comparison
+        String normalizedInput = input.replace("+", "%20");
+
+        return normalizedInput.equals(encoded);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/converter/MetadataEncoder.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/converter/MetadataEncoder.java
@@ -1,0 +1,42 @@
+package uk.gov.companieshouse.filetransferservice.service.converter;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetadataEncoder implements Converter<String, String> {
+
+    @Override
+    public String convert(final String source) {
+        try {
+            // Check if the input is empty, or already URL encoded?
+            if(isEmpty(source) || isUrlEncoded(source)) {
+                return source;
+            }
+
+            // Input is NOT URL encoded, so encode it.
+            return URLEncoder.encode(source, StandardCharsets.UTF_8).replace("+", "%20");
+
+        } catch (Exception e) {
+            // Something went wrong during encoding, return the original source.
+            return source;
+        }
+    }
+
+    private boolean isUrlEncoded(final String input) {
+        // Decode and re-encode, then compare
+        String decoded = URLDecoder.decode(input, StandardCharsets.UTF_8);
+        String encoded = URLEncoder.encode(decoded, StandardCharsets.UTF_8).replace("+", "%20");
+
+        // Normalize input for comparison
+        String normalizedInput = input.replace("+", "%20");
+
+        return normalizedInput.equals(encoded);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImpl.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/impl/AmazonFileTransferImpl.java
@@ -31,7 +31,6 @@ import uk.gov.companieshouse.logging.Logger;
 @Component
 public class AmazonFileTransferImpl implements AmazonFileTransfer {
 
-    private final String s3PathPrefix;
     private final S3Client s3Client;
     private final AWSServiceProperties properties;
     private final Logger logger;
@@ -40,7 +39,6 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
         this.s3Client = s3Client;
         this.logger = logger;
         this.properties = properties;
-        this.s3PathPrefix = properties.getS3PathPrefix();
 
         validateS3Details();
     }
@@ -53,7 +51,7 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
         logger.trace(format("uploadFile(fileId=%s, metaData=%s) method called.", fileId, metadata));
 
         try {
-            logger.debug(format("Uploading file '%s' to '%s'...", fileId, s3PathPrefix));
+            logger.debug(format("Uploading file '%s' to '%s'...", fileId, properties.getS3PathPrefix()));
 
             if (!metadata.containsKey(CONTENT_TYPE)) {
                 logger.error("Missing content-type");
@@ -171,7 +169,7 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
 
             s3Client.headBucket(headBucketRequest);
 
-            logger.trace(format("Bucket exists. [%s]", bucket));
+            logger.debug(format("Bucket exists: [%s]", bucket));
 
             return true;
 
@@ -186,7 +184,7 @@ public class AmazonFileTransferImpl implements AmazonFileTransfer {
     }
 
     private boolean validateS3Path() {
-        return getS3Path().toLowerCase().startsWith(s3PathPrefix);
+        return getS3Path().toLowerCase().startsWith(properties.getS3PathPrefix());
     }
 
     private boolean validateBucketName() {

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/storage/S3FileStorage.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/storage/S3FileStorage.java
@@ -135,10 +135,9 @@ public class S3FileStorage implements FileStorageStrategy {
 
             // Ensure metadata is case insensitive
             Map<String, String> metadata = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-            //metadata.putAll(decodedMap);
-            metadata.putAll(objectResponse.metadata());
+            metadata.putAll(decodedMap);
 
-            logger.info(format("Retrieved file metadata from S3: %s", metadata));
+            logger.info(format("Retrieved and decoded file metadata from S3: %s", metadata));
 
             FileDetailsApi fileDetailsApi = new FileDetailsApi(fileId,
                     avCreatedOn,

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/config/DefaultContentTypeFilterTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/config/DefaultContentTypeFilterTest.java
@@ -1,0 +1,95 @@
+package uk.gov.companieshouse.filetransferservice.config;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import uk.gov.companieshouse.logging.Logger;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultContentTypeFilterTest {
+
+    @Mock
+    private Logger logger;
+
+    private DefaultContentTypeFilter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new DefaultContentTypeFilter(logger);
+    }
+
+    @Test
+    @DisplayName("Test HttpServletRequest without a valid content-type header")
+    void testDoFilterWithPostAndContentType() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/json");
+        request.setMethod("POST");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        underTest.doFilter(request, response, chain);
+
+        verify(logger, times(0)).debug(anyString());
+    }
+
+    @Test
+    @DisplayName("Test HttpServletRequest without a valid content-type header")
+    void testDoFilterWithPostWithoutContentType() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType(null);
+        request.setMethod("POST");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        underTest.doFilter(request, response, chain);
+
+        verify(logger, times(1)).debug("Content-Type not detected within POST request, to "
+                + "preserve legacy client functionality we are wrapping request to set default Content-Type to application/json");
+    }
+
+    @Test
+    @DisplayName("Test HttpServletRequest without a valid content-type header")
+    void testDoFilterWithGetAndContentType() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/json");
+        request.setMethod("GET");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        underTest.doFilter(request, response, chain);
+
+        verify(logger, times(0)).debug(anyString());
+    }
+
+
+    @Test
+    @DisplayName("Test HttpServletRequest without a valid content-type header")
+    void testDoFilterWithGetWithoutContentType() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType(null);
+        request.setMethod("GET");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        underTest.doFilter(request, response, chain);
+
+        verify(logger, times(0)).debug(anyString());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/controller/FileTransferControllerTest.java
@@ -84,7 +84,7 @@ class FileTransferControllerTest {
 
         when(fileStorageStrategy.save(any(FileUploadApi.class))).thenReturn("123");
 
-        ResponseEntity<?> response = fileTransferController.uploadJson(fileApi);
+        ResponseEntity<?> response = fileTransferController.upload(fileApi);
 
         verify(fileStorageStrategy, times(1)).save(any(FileUploadApi.class));
 

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/service/converter/MetadataDecoderTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/service/converter/MetadataDecoderTest.java
@@ -1,0 +1,65 @@
+package uk.gov.companieshouse.filetransferservice.service.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MetadataDecoderTest {
+
+    private MetadataDecoder underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new MetadataDecoder();
+    }
+
+    @Test
+    @DisplayName("Test conversion of non-encoded filename to remain unchanged")
+    void givenNonEncodedFilename_whenConvertCalled_thenFilenameUnchanged() {
+        String input = "test file.txt";
+        String expectedOutput = "test file.txt";
+
+        String result = underTest.convert(input);
+
+        assertThat(result, is(expectedOutput));
+    }
+
+    @Test
+    @DisplayName("Test conversion of pre-encoded filename to URL decoded format")
+    void givenPreEncodedFilename_whenConvertCalled_thenFilenameDecoded() {
+        String input = "test%20file.txt";
+        String expectedOutput = "test file.txt";
+
+        String result = underTest.convert(input);
+
+        assertThat(result, is(expectedOutput));
+    }
+
+    @Test
+    @DisplayName("Test conversion of irregular filename to URL encoded format")
+    void givenIrregularFilename_whenConvertCalled_thenFilenameEncoded() {
+        String input = "CIC_D%E2%80%99Artagnan%20House%20C.I.C._31102024.zip";
+        String expectedOutput = "CIC_D’Artagnan House C.I.C._31102024.zip";
+
+        String result = underTest.convert(input);
+
+        assertThat(result, is(expectedOutput));
+    }
+
+    @Test
+    @DisplayName("Test conversion of malformed filename to URL decoded format")
+    void givenMalformedFilename_whenConvertCalled_thenFilenameEncoded() {
+        String input = "abc%2.zip";
+        String expectedOutput = "abc%2.zip";
+
+        String result = underTest.convert(input);
+
+        assertThat(result, is(expectedOutput));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/service/converter/MetadataEncoderTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/service/converter/MetadataEncoderTest.java
@@ -1,0 +1,66 @@
+package uk.gov.companieshouse.filetransferservice.service.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MetadataEncoderTest {
+
+    private MetadataEncoder underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new MetadataEncoder();
+    }
+
+    @Test
+    @DisplayName("Test conversion of non-encoded filename to URL encoded format")
+    void givenNonEncodedFilename_whenConvertCalled_thenFilenameEncoded() {
+        String input = "test file.txt";
+        String expectedOutput = "test%20file.txt";
+
+        String result = underTest.convert(input);
+
+        assertThat(result, is(expectedOutput));
+    }
+
+    @Test
+    @DisplayName("Test conversion of pre-encoded filename to URL encoded format")
+    void givenPreEncodedFilename_whenConvertCalled_thenFilenameEncoded() {
+        String input = "test%20file.txt";
+        String expectedOutput = "test%20file.txt";
+
+        String result = underTest.convert(input);
+
+        assertThat(result, is(expectedOutput));
+    }
+
+    @Test
+    @DisplayName("Test conversion of irregular filename to URL encoded format")
+    void givenIrregularFilename_whenConvertCalled_thenFilenameEncoded() {
+        String input = "CIC_D’Artagnan House C.I.C._31102024.zip";
+        String expectedOutput = "CIC_D%E2%80%99Artagnan%20House%20C.I.C._31102024.zip";
+
+        String result = underTest.convert(input);
+
+        assertThat(result, is(expectedOutput));
+    }
+
+    @Test
+    @DisplayName("Test conversion of malformed filename to URL encoded format")
+    void givenMalformedFilename_whenConvertCalled_thenFilenameEncoded() {
+        String input = "abc%2.zip";
+        String expectedOutput = "abc%2.zip";
+
+        String result = underTest.convert(input);
+
+        assertThat(result, is(expectedOutput));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/service/storage/S3FileStorageTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/service/storage/S3FileStorageTest.java
@@ -24,11 +24,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.ResponseInputStream;
@@ -40,6 +40,10 @@ import uk.gov.companieshouse.api.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.filetransferservice.model.FileDownloadApi;
 import uk.gov.companieshouse.filetransferservice.model.FileUploadApi;
 import uk.gov.companieshouse.filetransferservice.service.AmazonFileTransfer;
+import uk.gov.companieshouse.filetransferservice.service.converter.MetadataDecoder;
+import uk.gov.companieshouse.filetransferservice.service.converter.MetadataEncoder;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 @ExtendWith(MockitoExtension.class)
@@ -54,8 +58,15 @@ class S3FileStorageTest {
     @Mock
     private ByteArrayInputStream mockInputStream;
 
-    @InjectMocks
     private S3FileStorage underTest;
+
+    @BeforeEach
+    void setUp() {
+        Logger logger = LoggerFactory.getLogger("S3FileStorageTest");
+
+        underTest = new S3FileStorage(amazonFileTransfer, new MetadataEncoder(), new MetadataDecoder(),
+                logger, "test-service-path");
+    }
 
     @Test
     @DisplayName("Test successful File Save")


### PR DESCRIPTION
Fix backwards-compatibility issues with earlier versions of private-api-sdk-java. Changes to this service were difficult to hold the backwards-compatibility of the private-sdk, and the "upload" functionality was broken.