### PR TITLE
Add fallback for download when the metadata does not contain a Content-Type it will try the s3 object content type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,22 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
+            <!-- Temporary managed dependency, Force all netty artifacts to 4.2.15.Final update once software.amazon.awssdk:s3 > 2.46.5 has newer versions of netty -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.15.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Temporary managed dependency, Force all log4j artifacts to 2.26.0 update once sping-boot-dependencies >3.5.15 have a newer version of log4j-->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>2.26.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -109,163 +124,6 @@
               <groupId>org.apache.commons</groupId>
               <artifactId>commons-lang3</artifactId>
               <version>3.20.0</version>
-            </dependency>
-
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-34477
-                Review to see if spring-boot-starter >3.5.15
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.26.0</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-34477
-                Review to see if spring-boot-starter >3.5.15
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-                <version>2.26.0</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-classes-epoll</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-unix-common</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-buffer</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
-            </dependency>
-            <!-- Temporarily overridden dependencies
-                Override dependency to fix:
-                -  CVE-2026-41417
-                Review to see if s3 >2.46.5
-                supplies an updated version of this,
-                allowing removal of version of this dependency.
-            -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http2</artifactId>
-                <version>4.2.13.Final</version>
-                <scope>compile</scope>
             </dependency>
 
             <!-- Temporarily overridden dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <java.version>21</java.version>
 
-        <spring-boot-dependencies.version>3.5.15</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.5.15</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.5.9</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.5.9</spring-boot-maven-plugin.version>
 
         <maven-build-helper-plugin.version>3.2.0</maven-build-helper-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -61,22 +61,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Temporary managed dependency, Force all netty artifacts to 4.2.13.Final update once software.amazon.awssdk:s3 has newer versions of netty -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.2.13.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- Temporary managed dependency, Force all log4j artifacts to 2.25.4 update once sping-boot-dependencies have a newer version of log4j-->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>2.25.4</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -117,6 +101,12 @@
               <groupId>org.apache.commons</groupId>
               <artifactId>commons-lang3</artifactId>
               <version>3.20.0</version>
+            </dependency>
+            <!-- Temporary managed override -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.25.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <java.version>21</java.version>
 
-        <spring-boot-dependencies.version>3.5.9</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.5.9</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.5.15</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.5.15</spring-boot-maven-plugin.version>
 
         <maven-build-helper-plugin.version>3.2.0</maven-build-helper-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -61,6 +61,22 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Temporary managed dependency, Force all netty artifacts to 4.2.13.Final update once software.amazon.awssdk:s3 has newer versions of netty -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.2.13.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Temporary managed dependency, Force all log4j artifacts to 2.25.4 update once sping-boot-dependencies have a newer version of log4j-->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>2.25.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -101,12 +117,6 @@
               <groupId>org.apache.commons</groupId>
               <artifactId>commons-lang3</artifactId>
               <version>3.20.0</version>
-            </dependency>
-            <!-- Temporary managed override -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.25.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/uk/gov/companieshouse/filetransferservice/service/storage/S3FileStorage.java
+++ b/src/main/java/uk/gov/companieshouse/filetransferservice/service/storage/S3FileStorage.java
@@ -139,10 +139,15 @@ public class S3FileStorage implements FileStorageStrategy {
 
             logger.info(format("Retrieved and decoded file metadata from S3: %s", metadata));
 
+            String contentType = metadata.get(CONTENT_TYPE);
+            if (contentType == null || contentType.isBlank()) {
+                contentType = objectResponse.contentType();
+            }
+
             FileDetailsApi fileDetailsApi = new FileDetailsApi(fileId,
                     avCreatedOn,
                     avStatus,
-                    metadata.get(CONTENT_TYPE),
+                    contentType,
                     objectResponse.contentLength(),
                     metadata.get(FILENAME_METADATA_KEY),
                     objectResponse.lastModified().toString(),

--- a/src/test/java/uk/gov/companieshouse/filetransferservice/service/storage/S3FileStorageTest.java
+++ b/src/test/java/uk/gov/companieshouse/filetransferservice/service/storage/S3FileStorageTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.filetransferservice.service.storage;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -192,6 +193,44 @@ class S3FileStorageTest {
         assertTrue(actual.isEmpty());
         verify(amazonFileTransfer).getFileObject(anyString());
         verify(amazonFileTransfer).getFileTags(anyString());
+    }
+
+    @Test
+    @DisplayName("Test success Get File Details when metadata contains content type")
+    void testGetFileDetailsSuccessWhenMetadataMissingContentType() {
+        GetObjectResponse.Builder objectResponseBuilder = createTestS3ObjectWithNullTags();
+        objectResponseBuilder.metadata(Map.of("Content-Type", "image/jpeg"));
+        objectResponseBuilder.contentType("application/octet-stream");
+
+        when(amazonFileTransfer.getFileObject(anyString())).thenReturn(Optional.of(
+                new ResponseInputStream<>(objectResponseBuilder.build(), mockInputStream)
+        ));
+
+        Optional<FileDetailsApi> actual = underTest.getFileDetails(TEST_FILE_NAME);
+
+        assertTrue(actual.isPresent());
+        assertNotNull(actual.get().getContentType());
+        assertEquals("image/jpeg", actual.get().getContentType());
+        verify(amazonFileTransfer).getFileObject(anyString());
+    }
+
+    @Test
+    @DisplayName("Test success Get File Details when metadata missing content type and S3 has content type")
+    void testGetFileDetailsSuccessWhenMetadataContentTypeMissingAndS3ContentTypePresent() {
+        GetObjectResponse.Builder objectResponseBuilder = createTestS3ObjectWithNullTags();
+        objectResponseBuilder.metadata(null);
+        objectResponseBuilder.contentType("image/jpeg");
+
+        when(amazonFileTransfer.getFileObject(anyString())).thenReturn(Optional.of(
+                new ResponseInputStream<>(objectResponseBuilder.build(), mockInputStream)
+        ));
+
+        Optional<FileDetailsApi> actual = underTest.getFileDetails(TEST_FILE_NAME);
+
+        assertTrue(actual.isPresent());
+        assertNotNull(actual.get().getContentType());
+        assertEquals("image/jpeg", actual.get().getContentType());
+        verify(amazonFileTransfer).getFileObject(anyString());
     }
 
     @Test


### PR DESCRIPTION
This was found while migrating the file transfer service for strike-off-objections-api

The upload function in the service creates the metadata Content-Type tag which if not present will fail download.

As the previous objects moved from the strike off bucket don't have a metadata Content-Type field we want to read the s3 object Content-Type field for those objects for which a fallback is added.

Tested locally for object 

https://eu-west-2.console.aws.amazon.com/s3/object/s3av-cidev?region=eu-west-2&prefix=08a00c62-d9ac-4fc2-9abc-2b655d7a9ffb
 
and it works fine 

Ticket: https://companieshouse.atlassian.net/browse/ASM-2091